### PR TITLE
Fix startup race condition: subscribe to MQTT topics before requesting data

### DIFF
--- a/custom_components/sofabaton_hub/__init__.py
+++ b/custom_components/sofabaton_hub/__init__.py
@@ -58,11 +58,11 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         "api_client": api_client,
     }
 
-    # First data refresh (before subscribing to MQTT topics to avoid receiving messages before data initialization)
-    await coordinator.async_config_entry_first_refresh()
-
-    # Subscribe to MQTT topics
+    # Subscribe to MQTT topics before requesting data to ensure responses are captured
     await api_client.async_subscribe_to_topics()
+
+    # First data refresh (now that subscriptions are in place)
+    await coordinator.async_config_entry_first_refresh()
 
     # Set up platforms (e.g., remote)
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)


### PR DESCRIPTION
## Problem

On startup, the integration publishes the activity list request to the MQTT broker
*before* subscribing to the response topic. If the hub responds before the
subscription is established (which frequently happens since MQTT round-trips are
fast), the response is silently lost.

The coordinator then waits up to 10 seconds for the activity list to populate
and times out, leaving the integration with an empty/uninitialized activity list.

## Why the original ordering was chosen (and why it's safe to change)

The existing comment says the refresh was intentionally done before subscribing
"to avoid receiving messages before data initialization". The concern seems to be
that incoming MQTT messages could hit the coordinator before its data structure
is ready.

However, this isn't actually a risk — the coordinator's `__init__` already
initializes the full `self.data` structure (activities, devices, keys, etc.)
before either call runs. Additionally, every message handler calls
`_ensure_data_initialized()` as a safety check. The handlers are also defensive
against unexpected state (e.g., `_handle_activity_status` logs a warning and
no-ops if an activity ID isn't in the dict yet).

So the data structure is ready to receive messages by the time `async_setup_entry()`
reaches these calls. The original ordering traded a theoretical concern for a
real bug — the response to the activity list request is missed because nothing
is listening yet.

## Fix

Swap the order of operations in `async_setup_entry()` so that MQTT topic
subscriptions are established before the first data request is published.
This ensures the response is always captured.