### PR TITLE
Fix startup race condition: verify MQTT subscriptions before requesting data

### DIFF
--- a/custom_components/sofabaton_hub/__init__.py
+++ b/custom_components/sofabaton_hub/__init__.py
@@ -58,11 +58,11 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         "api_client": api_client,
     }
 
-    # First data refresh (before subscribing to MQTT topics to avoid receiving messages before data initialization)
-    await coordinator.async_config_entry_first_refresh()
-
-    # Subscribe to MQTT topics
+    # Subscribe to MQTT topics before requesting data to ensure responses are captured
     await api_client.async_subscribe_to_topics()
+
+    # First data refresh (now that subscriptions are in place)
+    await coordinator.async_config_entry_first_refresh()
 
     # Set up platforms (e.g., remote)
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)

--- a/custom_components/sofabaton_hub/__init__.py
+++ b/custom_components/sofabaton_hub/__init__.py
@@ -58,10 +58,18 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         "api_client": api_client,
     }
 
-    # Subscribe to MQTT topics before requesting data to ensure responses are captured
+    # Subscribe to MQTT topics and verify subscriptions are active before
+    # publishing any requests. The barrier loopback confirms the broker has
+    # fully processed all subscriptions, preventing the race condition where
+    # a request is published before the response subscription is confirmed.
     await api_client.async_subscribe_to_topics()
+    await api_client.async_verify_subscriptions()
 
-    # First data refresh (now that subscriptions are in place)
+    # Now that subscriptions are verified, set the coordinator's message
+    # callback so incoming MQTT messages are processed.
+    api_client.set_on_message_callback(coordinator._handle_mqtt_message)
+
+    # First data refresh (subscriptions are confirmed active)
     await coordinator.async_config_entry_first_refresh()
 
     # Set up platforms (e.g., remote)

--- a/custom_components/sofabaton_hub/api.py
+++ b/custom_components/sofabaton_hub/api.py
@@ -172,15 +172,16 @@ class SofabatonHubApiClient:
 
         self._on_message_callback = _barrier_check
 
-        # Clear any previously retained barrier message to avoid stale loopbacks
-        await mqtt.async_publish(self.hass, barrier_topic, "", retain=True)
-
-        # Publish a non-retained barrier message for this verification
+        # Publish a retained barrier message. Retained is essential here:
+        # the broker delivers retained messages to subscribers when their
+        # subscription is confirmed (SUBACK). A non-retained message would
+        # only reach already-confirmed subscribers, defeating the purpose.
         _LOGGER.debug("Publishing subscription barrier to %s", barrier_topic)
         await mqtt.async_publish(
             self.hass,
             barrier_topic,
             json.dumps({"status": "ready"}),
+            retain=True,
         )
 
         try:
@@ -202,6 +203,11 @@ class SofabatonHubApiClient:
             if self._barrier_unsub:
                 self._barrier_unsub()
                 self._barrier_unsub = None
+
+            # Clear the retained barrier message from the broker so it doesn't
+            # linger between restarts. Publishing an empty payload with retain
+            # tells the broker to delete the retained message.
+            await mqtt.async_publish(self.hass, barrier_topic, "", retain=True)
 
     # --- Request publishing methods ---
 

--- a/custom_components/sofabaton_hub/api.py
+++ b/custom_components/sofabaton_hub/api.py
@@ -25,6 +25,7 @@ from .const import (
     TOPIC_ACTIVITY_MACRO_KEY_CONTROL,
     TOPIC_ACTIVITY_MACRO_LIST,
     TOPIC_ACTIVITY_MACRO_REQUEST,
+    TOPIC_SUBSCRIPTION_BARRIER,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -130,6 +131,9 @@ class SofabatonHubApiClient:
             # Uncomment below when re-enabling device support
             # TOPIC_DEVICE_KEYS_LIST,
             TOPIC_ACTIVITY_MACRO_LIST,
+            # Barrier topic must be last — used by async_verify_subscriptions()
+            # to confirm all preceding subscriptions are active
+            TOPIC_SUBSCRIPTION_BARRIER,
         ]
 
         for topic_template in topics_to_subscribe:
@@ -137,6 +141,50 @@ class SofabatonHubApiClient:
             _LOGGER.info("Subscribing to topic: %s", topic)
             # Subscribe to topic and specify callback function for message arrival
             await mqtt.async_subscribe(self.hass, topic, self._message_received)
+
+    async def async_verify_subscriptions(self) -> None:
+        """Verify MQTT subscriptions are active using a self-loopback barrier.
+
+        Publishes a retained message to the barrier topic and waits for it to
+        arrive back through the subscription. Since all topics are subscribed
+        sequentially and the barrier topic is last, receiving the loopback
+        confirms the broker has processed all subscriptions.
+
+        This must be called after async_subscribe_to_topics() and before
+        setting the coordinator's message callback or publishing any requests.
+        """
+        barrier_topic = self._get_topic(TOPIC_SUBSCRIPTION_BARRIER)
+        barrier_received = asyncio.Event()
+
+        # Temporarily set a barrier callback to detect the loopback.
+        # No coordinator callback is set yet at this point in the startup
+        # sequence, so we own _on_message_callback exclusively.
+        def _barrier_check(topic: str, payload: dict) -> None:
+            if topic == barrier_topic and payload.get("status") == "ready":
+                barrier_received.set()
+
+        self._on_message_callback = _barrier_check
+
+        _LOGGER.debug("Publishing subscription barrier to %s", barrier_topic)
+        await mqtt.async_publish(
+            self.hass,
+            barrier_topic,
+            json.dumps({"status": "ready"}),
+            retain=True,
+        )
+
+        try:
+            async with asyncio.timeout(5.0):
+                await barrier_received.wait()
+            _LOGGER.info("MQTT subscriptions verified via barrier loopback")
+        except TimeoutError:
+            _LOGGER.warning(
+                "MQTT subscription barrier timed out after 5s, proceeding anyway"
+            )
+        finally:
+            # Clear the temporary callback; the coordinator callback will be
+            # set by __init__.py after this method returns.
+            self._on_message_callback = None
 
     # --- Request publishing methods ---
 

--- a/custom_components/sofabaton_hub/api.py
+++ b/custom_components/sofabaton_hub/api.py
@@ -46,6 +46,7 @@ class SofabatonHubApiClient:
         self.mac: str = entry.data[CONF_MAC]
         self._on_message_callback: Callable[[str, dict[str, Any]], None] | None = None
         self._request_lock = asyncio.Lock()
+        self._barrier_unsub: Callable[[], None] | None = None
 
     def set_on_message_callback(self, func: Callable[[str, dict[str, Any]], None]) -> None:
         """Set callback function to be called when MQTT message is received.
@@ -139,16 +140,22 @@ class SofabatonHubApiClient:
         for topic_template in topics_to_subscribe:
             topic = self._get_topic(topic_template)
             _LOGGER.info("Subscribing to topic: %s", topic)
-            # Subscribe to topic and specify callback function for message arrival
-            await mqtt.async_subscribe(self.hass, topic, self._message_received)
+            unsub = await mqtt.async_subscribe(self.hass, topic, self._message_received)
+            # Keep the barrier unsubscribe callback so we can remove it after
+            # verification — it's only needed during startup.
+            if topic_template == TOPIC_SUBSCRIPTION_BARRIER:
+                self._barrier_unsub = unsub
 
     async def async_verify_subscriptions(self) -> None:
         """Verify MQTT subscriptions are active using a self-loopback barrier.
 
-        Publishes a retained message to the barrier topic and waits for it to
-        arrive back through the subscription. Since all topics are subscribed
+        Publishes a message to the barrier topic and waits for it to arrive
+        back through the subscription. Since all topics are subscribed
         sequentially and the barrier topic is last, receiving the loopback
         confirms the broker has processed all subscriptions.
+
+        After verification, the barrier subscription is removed so it does not
+        generate unexpected messages during normal operation.
 
         This must be called after async_subscribe_to_topics() and before
         setting the coordinator's message callback or publishing any requests.
@@ -165,12 +172,15 @@ class SofabatonHubApiClient:
 
         self._on_message_callback = _barrier_check
 
+        # Clear any previously retained barrier message to avoid stale loopbacks
+        await mqtt.async_publish(self.hass, barrier_topic, "", retain=True)
+
+        # Publish a non-retained barrier message for this verification
         _LOGGER.debug("Publishing subscription barrier to %s", barrier_topic)
         await mqtt.async_publish(
             self.hass,
             barrier_topic,
             json.dumps({"status": "ready"}),
-            retain=True,
         )
 
         try:
@@ -185,6 +195,13 @@ class SofabatonHubApiClient:
             # Clear the temporary callback; the coordinator callback will be
             # set by __init__.py after this method returns.
             self._on_message_callback = None
+
+            # Unsubscribe from the barrier topic — it's only needed during
+            # startup verification and would generate spurious messages if
+            # left active during normal operation.
+            if self._barrier_unsub:
+                self._barrier_unsub()
+                self._barrier_unsub = None
 
     # --- Request publishing methods ---
 

--- a/custom_components/sofabaton_hub/const.py
+++ b/custom_components/sofabaton_hub/const.py
@@ -45,6 +45,12 @@ TOPIC_ACTIVITY_MACRO_LIST = "activity/{mac}/macro_keys_list"
 TOPIC_ACTIVITY_ASSIGNED_KEY_CONTROL = "activity/{mac}/keys_control"
 TOPIC_ACTIVITY_MACRO_KEY_CONTROL = "activity/{mac}/macro_keys_control"
 
+# Subscription verification barrier topic
+# Used to confirm MQTT subscriptions are fully active before publishing requests.
+# The integration subscribes to this topic, publishes a retained message to it,
+# and waits for the loopback — proving the broker has confirmed all subscriptions.
+TOPIC_SUBSCRIPTION_BARRIER = "activity/{mac}/subscription_barrier"
+
 # Device-related topics
 TOPIC_DEVICE_LIST_REQUEST = "device/{mac}/list_request"
 TOPIC_DEVICE_LIST_RESPONSE = "device/{mac}/list"

--- a/custom_components/sofabaton_hub/coordinator.py
+++ b/custom_components/sofabaton_hub/coordinator.py
@@ -74,8 +74,9 @@ class SofabatonHubDataUpdateCoordinator(DataUpdateCoordinator):
         self._basic_data_request_state = None  # Basic data request state
         self._basic_data_timeout = None  # Basic data request timeout
 
-        # Set MQTT message callback
-        self.api_client.set_on_message_callback(self._handle_mqtt_message)
+        # Note: The MQTT message callback is set by __init__.py after the
+        # subscription barrier has been verified, not here. This ensures no
+        # messages are processed before the startup sequence is ready.
 
         # Initialize data structure
         self.data: dict[str, Any] = {


### PR DESCRIPTION
## Problem

On startup, the integration's request for the activity list frequently fails,
leaving it with an empty/uninitialized activity list. This happens because of
a race condition between subscribing to MQTT response topics and publishing
requests to the hub.

The original code published the request *before* subscribing. Reordering
alone wasn't sufficient, `mqtt.async_subscribe` returns before the broker
has confirmed the subscription (SUBACK), so with only milliseconds between
subscribing and publishing, the hub's response is still lost.

## Why the original ordering was chosen (and why it's safe to change)

The existing comment says the refresh was intentionally done before subscribing
"to avoid receiving messages before data initialization". The concern was that
incoming MQTT messages could hit the coordinator before its data structure
was ready.

However, this isn't a risk, the coordinator's `__init__` initializes the full
`self.data` structure before `async_setup_entry()` runs, and every message
handler calls `_ensure_data_initialized()` as a safety check. The original
ordering traded a theoretical concern for a real bug.

## Fix

Introduce a **self-loopback barrier** mechanism to verify subscriptions are
fully active before publishing any requests:

1. Subscribe to all MQTT topics, including a new barrier topic (last)
2. Publish a **retained** message to the barrier topic
3. Wait for it to arrive back through the subscription callback
4. Receiving the loopback proves the broker has confirmed all subscriptions
5. Clean up: unsubscribe from the barrier topic and clear the retained
   message from the broker (publish empty payload with retain=True)
6. Set the coordinator's message callback and proceed with the data request

The retained flag is essential: the broker delivers retained messages to
subscribers when their subscription is confirmed (SUBACK). A non-retained
message would only reach already-confirmed subscribers, defeating the purpose.

This makes the startup sequence deterministic:
**subscribe → verify barrier → clean up → set callback → request data**

The coordinator's message callback is now set by `__init__.py` after barrier
verification, rather than prematurely in the coordinator's constructor. This
also ensures no MQTT messages are processed before the startup sequence is
ready.

### Files changed
- `const.py` — new `TOPIC_SUBSCRIPTION_BARRIER` constant
- `api.py` — barrier topic in subscription list; `async_verify_subscriptions()`
  with retained message cleanup and unsubscribe
- `coordinator.py` — callback setup moved out of `__init__`
- `__init__.py` — deterministic startup sequence