### PR TITLE
Trust hub push for activity state, remove post-command polling

### DIFF
--- a/custom_components/sofabaton_hub/coordinator.py
+++ b/custom_components/sofabaton_hub/coordinator.py
@@ -672,15 +672,25 @@ class SofabatonHubDataUpdateCoordinator(DataUpdateCoordinator):
                 self.data["activities"][activity_id]["state"] = "on"
                 self.data["current_activity_id"] = activity_id
             else:
-                _LOGGER.warning("Received unknown activity_id: %s", activity_id)
+                # Unknown activity_id: the hub says this activity is active, so trust it.
+                # Update current_activity_id immediately so state is correct,
+                # then request the activity list to recover the missing metadata.
+                _LOGGER.warning(
+                    "Received unknown activity_id %s, updating state and requesting activity list",
+                    activity_id,
+                )
+                self.data["current_activity_id"] = activity_id
+                asyncio.create_task(self.async_request_basic_data())
         elif activity_id is not None and state == "off":
             # Individual activity closed (rare case)
             _LOGGER.info("Individual activity %s turned off", activity_id)
             if activity_id in self.data["activities"]:
                 self.data["activities"][activity_id]["state"] = "off"
-                # If closing current activity, clear current_activity_id
-                if self.data["current_activity_id"] == activity_id:
-                    self.data["current_activity_id"] = None
+            # If closing current activity, clear current_activity_id
+            # (check regardless of whether activity is in our list — it may have been
+            # set by a previous push for an unknown activity_id)
+            if self.data["current_activity_id"] == activity_id:
+                self.data["current_activity_id"] = None
         else:
             _LOGGER.warning("Unhandled activity status: activity_id=%s, state=%s", activity_id, state)
 

--- a/custom_components/sofabaton_hub/remote.py
+++ b/custom_components/sofabaton_hub/remote.py
@@ -172,8 +172,7 @@ class SofabatonHubRemote(CoordinatorEntity[SofabatonHubDataUpdateCoordinator], R
         if current_activity_id:
             # Send stop command, use 0xFF to stop all
             await self.coordinator.api_client.async_control_activity_state(0xFF, "off")
-            # Request basic data to update activity states in frontend
-            await self.coordinator.async_request_basic_data()
+            # State will be updated when the hub pushes activity status via MQTT
 
     async def async_send_command(self, command: Iterable[str], **kwargs: Any) -> None:
         """Send a command to the device.
@@ -215,13 +214,11 @@ class SofabatonHubRemote(CoordinatorEntity[SofabatonHubDataUpdateCoordinator], R
         if cmd_type == "start_activity":
             _LOGGER.info("Backend: Starting activity %s", cmd_dict["activity_id"])
             await api.async_control_activity_state(cmd_dict["activity_id"], "on")
-            # Request basic data to update activity states in frontend
-            await self.coordinator.async_request_basic_data()
+            # State will be updated when the hub pushes activity status via MQTT
         elif cmd_type == "stop_activity":
             _LOGGER.info("Backend: Stopping activity %s", cmd_dict["activity_id"])
             await api.async_control_activity_state(cmd_dict["activity_id"], "off")
-            # Request basic data to update activity states in frontend
-            await self.coordinator.async_request_basic_data()
+            # State will be updated when the hub pushes activity status via MQTT
         elif cmd_type == "request_assigned_keys":
             # Request assigned_keys (page 1)
             activity_id = cmd_dict.get("activity_id")

--- a/custom_components/sofabaton_hub/switch.py
+++ b/custom_components/sofabaton_hub/switch.py
@@ -247,11 +247,7 @@ class SofabatonActivitySwitch(CoordinatorEntity, SwitchEntity):
         try:
             await self.coordinator.api_client.async_start_activity(self._activity_id)
             _LOGGER.info("Successfully sent start command for activity %s", self._activity_id)
-
-            # Request basic data to update activity states
-            # This will trigger MQTT request and update the coordinator data
-            # Note: If request is already in progress, this will be skipped
-            await self.coordinator.async_request_basic_data()
+            # State will be updated when the hub pushes activity status via MQTT
 
         except Exception as err:
             _LOGGER.error(
@@ -272,11 +268,7 @@ class SofabatonActivitySwitch(CoordinatorEntity, SwitchEntity):
         try:
             await self.coordinator.api_client.async_stop_activity(self._activity_id)
             _LOGGER.info("Successfully sent stop command for activity %s", self._activity_id)
-
-            # Request basic data to update activity states
-            # This will trigger MQTT request and update the coordinator data
-            # Note: If request is already in progress, this will be skipped
-            await self.coordinator.async_request_basic_data()
+            # State will be updated when the hub pushes activity status via MQTT
 
         except Exception as err:
             _LOGGER.error(


### PR DESCRIPTION
## Problem

After sending an activity control command (start/stop), the integration immediately
calls `async_request_basic_data()` to poll the hub for the updated activity list.
This causes two issues:

1. **Stale/incorrect state:** The hub takes a few seconds to process activity
   transitions (running shutdown and startup sequences). Polling during this window
   can return incomplete data, an empty list, or shows the wrong activity as active.
   The `_handle_activity_list` handler then clears and rebuilds the activity dict
   from this stale response, overwriting the correct state that was already set by
   the hub's real-time push.

2. **Multiple state change notifications:** Downstream consumers (automations,
   custom cards) observe state changes via the coordinator. The post-command poll
   causes a second `async_set_updated_data` call with potentially different data
   than the hub's push, so consumers may see spurious state transitions and fire
   their logic multiple times, possibly sending their own commands to the hub that
   conflict with the still-in-progress transition.

## Approach

The hub already proactively pushes activity state changes via the
`activity_control_up` MQTT topic. This is the authoritative real-time signal.
The integration's `_handle_activity_status` handler processes these pushes and
updates state immediately, no follow-up poll is needed.

This PR removes the `async_request_basic_data()` calls that followed activity
control commands in `switch.py` (turn_on/turn_off) and `remote.py`
(turn_off, start_activity, stop_activity send_commands). The explicit
`request_basic_data` send_command type is preserved, it's used by the frontend
for manual refresh and is not tied to activity control.

## Edge case: unknown activity ID in hub push

If the hub pushes a status update for an activity_id that isn't in our activity
list (e.g. after an incomplete startup where the initial activity list was empty
or partial), the handler previously just logged a warning and dropped the update.

Now it trusts the hub: `current_activity_id` is updated immediately so the
integration's on/off state is correct, and the activity list is requested in the
background to recover the missing metadata (name, etc.). This is the only scenario
where a follow-up request is made, it's a recovery path, not a post-command poll.

## Remaining edge case: deleted or renamed activity

With this PR the integration will not automatically pick up on Activities that are renamed or have been deleted. A reload of the integration is required to synchronize for these cases. Perhaps this needs to further evolve to include persistent cache and/or a cache refresh mechanism.

## Testing

- Switch activities via the HA UI or automation and verify state updates arrive
  via the hub push (no redundant activity list requests in the logs)
- Trigger an activity change from the physical remote while HA is running
- Restart HA and immediately switch activities from the physical remote to
  exercise the unknown activity_id recovery path