### PR TITLE
Fix diagnostics: access coordinator from correct data structure

### DIFF
--- a/custom_components/sofabaton_hub/diagnostics.py
+++ b/custom_components/sofabaton_hub/diagnostics.py
@@ -149,8 +149,8 @@ def _get_coordinator_state_diagnostics(
     return {
         "last_update_success": coordinator.last_update_success,
         "last_update_time": (
-            coordinator.last_update_success_time.isoformat()
-            if coordinator.last_update_success_time
+            getattr(coordinator, "last_update_success_time", None).isoformat()
+            if getattr(coordinator, "last_update_success_time", None)
             else None
         ),
         "update_interval": (

--- a/custom_components/sofabaton_hub/diagnostics.py
+++ b/custom_components/sofabaton_hub/diagnostics.py
@@ -22,7 +22,7 @@ async def async_get_config_entry_diagnostics(
     Returns:
         Dictionary containing diagnostic information with sensitive data redacted
     """
-    coordinator: SofabatonHubDataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
+    coordinator: SofabatonHubDataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]["coordinator"]
     
     # Get coordinator data
     data = coordinator.data or {}


### PR DESCRIPTION
# Problem

The "Download diagnostics" button on the device page fails. The diagnostics
handler accesses `hass.data[DOMAIN][entry.entry_id]` directly, expecting the
coordinator object. However, `async_setup_entry` stores a dict at that key:

    {"coordinator": coordinator, "api_client": api_client}

This causes an `AttributeError` when the handler tries to access `.data` on the dict.

## Fix

Access the coordinator via the `"coordinator"` key:

    hass.data[DOMAIN][entry.entry_id]["coordinator"]

## Testing

- Go to the Sofabaton Hub device page and click "Download diagnostics"
- Verify a JSON file is downloaded with activity list, coordinator state, and redacted config